### PR TITLE
Consistent method naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,26 @@ What is Hamcrest-Path?
 Hamcrest-Path is a [hamcrest][] extension library,
 which provides a suite of hamcrest-style matchers for file/directory existence and permissions.
 
+Without the hamcrest-path library, testing whether a file is readable would need to be written as:
+
+        Path path = Paths.get("/path/to/some/file");
+        assertThat(Files.isReadable(path), is(true));
+
+If the test failed, a non-informative error message would be generated stating
+an accurate but cryptic message: "Expected: is <`true`>, but: was <`false`>".
+With the hamcrest-path library, the test can be re-written as:
+
+        Path path = Paths.get("/path/to/some/file");
+        assertThat(path, is(readable()));
+
+Not only is this more concise, but if the assertion fails, a more informative error message is generated:
+"Expected: is a readable file or directory, but: </path/to/some/file> does not exist." 
+
+
 
 Downloads
 ---------
-You can obtain the hamcrest-path binaries from [maven central][], or download them automatically in maven using:
+You can obtain the hamcrest-path binaries from [maven central][], or download them automatically in Maven using:
 
 	<dependencies>
 	    <dependency>
@@ -25,10 +41,10 @@ You can obtain the hamcrest-path binaries from [maven central][], or download th
 Usage
 -----
 The following code tests whether the user's home directory exists,
-is readable, and is writable:
+and is both readable and writable:
 
     import static ca.seinesoftware.hamcrest.path.PathMatcher.*;
-    import static org.hamcrest.Matchers.is;
+    import static org.hamcrest.Matchers.*;
     import static org.junit.Assert.assertThat;
 
     import java.nio.file.Path;
@@ -42,8 +58,7 @@ is readable, and is writable:
             Path home = Paths.get(System.getProperty("user.home"));
             assertThat(home, exists());
             assertThat(home, is(aDirectory());
-            assertThat(home, is(readable()));
-            assertThat(home, is(writable()));
+            assertThat(home, is(both(readable()).and(writable())));
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and is both readable and writable:
 
 Other matchers include:
 * __aRegularFile__ - Tests whether the file system entry is a regular file
-* __symbolicLink__ - Tests whether the file system entry is a symbolic link
+* __aSymbolicLink__ - Tests whether the file system entry is a symbolic link
 * __sameFile__ - Tests if two paths reference the same file system entry
 * __executable__ - Test whether the user has execute permissions for the file system entry
 * __hidden__ - Test whether the file system entry is hidden

--- a/README.md
+++ b/README.md
@@ -5,38 +5,45 @@ Licensed under [BSD License][].
 
 What is Hamcrest-Path?
 ----------------------
-Hamcrest-Path is a [hamcrest][] extension library,
+Hamcrest-Path is a [Java Hamcrest][] extension library,
 which provides a suite of hamcrest-style matchers for file/directory existence and permissions.
 
 Without the hamcrest-path library, testing whether a file is readable would need to be written as:
 
-        Path path = Paths.get("/path/to/some/file");
-        assertThat(Files.isReadable(path), is(true));
+    Path path = Paths.get("/path/to/some/file");
+    assertThat(Files.isReadable(path), is(true));
 
 If the test failed, a non-informative error message would be generated stating
-an accurate but cryptic message: "Expected: is <`true`>, but: was <`false`>".
+an accurate but cryptic message:
+
+    Expected: is <true>, but: was <false>
+
 With the hamcrest-path library, the test can be re-written as:
 
-        Path path = Paths.get("/path/to/some/file");
-        assertThat(path, is(readable()));
+    Path path = Paths.get("/path/to/some/file");
+    assertThat(path, is(readable()));
 
 Not only is this more concise, but if the assertion fails, a more informative error message is generated:
-"Expected: is a readable file or directory, but: </path/to/some/file> does not exist." 
 
+    Expected: is a readable file or directory, but: </path/to/some/file> does not exist. 
 
 
 Downloads
 ---------
-You can obtain the hamcrest-path binaries from [maven central][], or download them automatically in Maven using:
+You can obtain the hamcrest-path binaries from [maven central][], To include in your project:
 
-	<dependencies>
-	    <dependency>
-	        <groupId>ca.seinesoftware</groupId>
-	        <artifactId>hamcrest-path</artifactId>
-	        <version>1.0.0</version>
-	        <scope>test</scope>
-	    </dependency>
-	</dependencies>
+A Maven project:
+
+    <dependency>
+	    <groupId>ca.seinesoftware</groupId>
+	    <artifactId>hamcrest-path</artifactId>
+	    <version>1.0.0</version>
+	    <scope>test</scope>
+	</dependency>
+
+A project which uses ivy for dependency management:
+
+    <dependency org="ca.seinesoftware" name="hamcrest-path" rev="1.0.0"/>
 
 Usage
 -----
@@ -46,12 +53,12 @@ and is both readable and writable:
     import static ca.seinesoftware.hamcrest.path.PathMatcher.*;
     import static org.hamcrest.Matchers.*;
     import static org.junit.Assert.assertThat;
-
+    
     import java.nio.file.Path;
     import java.nio.file.Paths;
-
+    
     import org.junit.Test;
-
+    
     public class HomeTest {
         @Test
         public void testHomeDirectory() {
@@ -62,12 +69,28 @@ and is both readable and writable:
         }
     }
 
+Other matchers include:
+* __aRegularFile__ - Tests whether the file system entry is a regular file
+* __symbolicLink__ - Tests whether the file system entry is a symbolic link
+* __sameFile__ - Tests if two paths reference the same file system entry
+* __executable__ - Test whether the user has execute permissions for the file system entry
+* __hidden__ - Test whether the file system entry is hidden
+
+
 Reporting Bugs/Issues
 ---------------------
 If you find an issue with Java Hamcrest, please report it via the 
 [GitHub issue tracker](https://github.com/seinesoftware/hamcrest-path/issues), 
 after first checking that it hasn't been raised already. 
 
+
+Acknowledgements
+----------------
+Thanks to the developers at [Java Hamcrest][].
+Without their hardwork and core libraries there'd be nothing to be extend and we be stuck with old school,
+non-declarative, non-reusable, assertions.
+
+
 [BSD License]: http://opensource.org/licenses/BSD-3-Clause
 [Maven central]: http://search.maven.org/#search%7Cga%7C1%7Cg%3Aca.seinesoftware
-[hamcrest]: https://github.com/hamcrest/JavaHamcrest
+[Java Hamcrest]: http://github.com/hamcrest/JavaHamcrest

--- a/src/main/java/ca/seinesoftware/hamcrest/path/PathMatcher.java
+++ b/src/main/java/ca/seinesoftware/hamcrest/path/PathMatcher.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.DosFileAttributes;
 
 import org.hamcrest.Description;
-import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
@@ -31,13 +30,13 @@ import org.hamcrest.TypeSafeMatcher;
  * import org.junit.Test;
  *
  * public class HomeTest {
- *     &#64;Test
- *     public void testHomeDirectory() {
- *         Path home = Paths.get(System.getProperty("user.home"));
- *         assertThat(home, exists());
- *         assertThat(home, is(readable());
- *         assertThat(home, is(writable());
- *     }
+ * 	   &#64;Test
+ * 	   public void testHomeDirectory() {
+ * 	       Path home = Paths.get(System.getProperty("user.home"));
+ * 	       assertThat(home, exists());
+ * 	       assertThat(home, is(aDirectory()));
+ * 	       assertThat(home, is(both(readable()).and(writable())));
+ * 	   }
  * }
  * </pre>
  *
@@ -159,7 +158,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 * @return {@code true} if the file exists; {@code false} if the file does
 	 *         not exist or its existence cannot be determined.
 	 */
-	@Factory
 	public static Matcher<Path> exists(final LinkOption... options) {
 		return new Exists(options);
 	}
@@ -185,7 +183,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *         path does not exist, is not a directory, or it cannot be
 	 *         determined if the path is a directory or not.
 	 */
-	@Factory
 	public static Matcher<Path> aDirectory(final LinkOption... options) {
 		return new Directory(options);
 	}
@@ -211,7 +208,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *         path does not exist, is not a regular file, or it cannot be
 	 *         determined if the path is a regular file or not.
 	 */
-	@Factory
 	public static Matcher<Path> aRegularFile(final LinkOption... options) {
 		return new RegularFile(options);
 	}
@@ -231,7 +227,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *         path does not exist, is not a symbolic link, or it cannot be
 	 *         determined if the path is a symbolic link or not.
 	 */
-	@Factory
 	public static Matcher<Path> symbolicLink() {
 		return new SymbolicLink();
 	}
@@ -252,7 +247,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *         Java virtual machine has insufficient privileges, or access
 	 *         cannot be determined
 	 */
-	@Factory
 	public static Matcher<Path> readable() {
 		return new Readable();
 	}
@@ -273,7 +267,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *         Java virtual machine has insufficient privileges, or access
 	 *         cannot be determined
 	 */
-	@Factory
 	public static Matcher<Path> writable() {
 		return new Writable();
 	}
@@ -297,7 +290,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *         because the Java virtual machine has insufficient privileges, or
 	 *         access cannot be determined
 	 */
-	@Factory
 	public static Matcher<Path> executable() {
 		return new Executable();
 	}
@@ -321,7 +313,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *         the path does not exist, the file is not hidden, or access cannot
 	 *         be determined
 	 */
-	@Factory
 	public static Matcher<Path> hidden() {
 		return new Hidden();
 	}
@@ -344,7 +335,6 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *            path to the expected file system object.
 	 * @return {@code true} if, and only if, the two paths locate the same file
 	 */
-	@Factory
 	public static Matcher<Path> sameFile(final Path expected) {
 		return new SameFile(expected);
 	}

--- a/src/main/java/ca/seinesoftware/hamcrest/path/PathMatcher.java
+++ b/src/main/java/ca/seinesoftware/hamcrest/path/PathMatcher.java
@@ -30,13 +30,13 @@ import org.hamcrest.TypeSafeMatcher;
  * import org.junit.Test;
  *
  * public class HomeTest {
- * 	   &#64;Test
- * 	   public void testHomeDirectory() {
- * 	       Path home = Paths.get(System.getProperty("user.home"));
- * 	       assertThat(home, exists());
- * 	       assertThat(home, is(aDirectory()));
- * 	       assertThat(home, is(both(readable()).and(writable())));
- * 	   }
+ * 	  &#64;Test
+ * 	  public void testHomeDirectory() {
+ * 	      Path home = Paths.get(System.getProperty("user.home"));
+ * 	      assertThat(home, exists());
+ * 	      assertThat(home, is(aDirectory()));
+ * 	      assertThat(home, is(both(readable()).and(writable())));
+ * 	  }
  * }
  * </pre>
  *
@@ -227,6 +227,30 @@ public abstract class PathMatcher extends TypeSafeMatcher<Path> {
 	 *         path does not exist, is not a symbolic link, or it cannot be
 	 *         determined if the path is a symbolic link or not.
 	 */
+	public static Matcher<Path> aSymbolicLink() {
+		return new SymbolicLink();
+	}
+
+	/**
+	 * Create a matcher that matches if the examined {@link Path} is a
+	 * <em>symbolic link</em>.
+	 *
+	 * <p>
+	 * For example:
+	 *
+	 * <pre>
+	 * assertThat(Paths.get("/tmp"), is(not(symbolicLink())));
+	 * </pre>
+	 *
+	 * @return {@code true} if the path is a symbolic link; {@code false} if the
+	 *         path does not exist, is not a symbolic link, or it cannot be
+	 *         determined if the path is a symbolic link or not.
+	 * @deprecated To be consistent with {@link #aRegularFile(LinkOption...)}
+	 *             and {@link #aDirectory(LinkOption...)}, this was renamed to
+	 *             {@link #aSymbolicLink()}
+	 *
+	 */
+	@Deprecated
 	public static Matcher<Path> symbolicLink() {
 		return new SymbolicLink();
 	}

--- a/src/test/java/ca/seinesoftware/hamcrest/path/HomeTest.java
+++ b/src/test/java/ca/seinesoftware/hamcrest/path/HomeTest.java
@@ -1,10 +1,7 @@
 package ca.seinesoftware.hamcrest.path;
 
-import static ca.seinesoftware.hamcrest.path.PathMatcher.aDirectory;
-import static ca.seinesoftware.hamcrest.path.PathMatcher.exists;
-import static ca.seinesoftware.hamcrest.path.PathMatcher.readable;
-import static ca.seinesoftware.hamcrest.path.PathMatcher.writable;
-import static org.hamcrest.Matchers.is;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.nio.file.Path;
@@ -18,7 +15,6 @@ public class HomeTest {
 		Path home = Paths.get(System.getProperty("user.home"));
 		assertThat(home, exists());
 		assertThat(home, is(aDirectory()));
-		assertThat(home, is(readable()));
-		assertThat(home, is(writable()));
+		assertThat(home, is(both(readable()).and(writable())));
 	}
 }

--- a/src/test/java/ca/seinesoftware/hamcrest/path/PathMatcherTest.java
+++ b/src/test/java/ca/seinesoftware/hamcrest/path/PathMatcherTest.java
@@ -3,9 +3,22 @@
  */
 package ca.seinesoftware.hamcrest.path;
 
-import static ca.seinesoftware.hamcrest.path.PathMatcher.*;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.aDirectory;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.aRegularFile;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.aSymbolicLink;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.executable;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.exists;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.hidden;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.readable;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.sameFile;
+import static ca.seinesoftware.hamcrest.path.PathMatcher.writable;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 
@@ -176,28 +189,28 @@ public class PathMatcherTest {
 
 	@Test
 	public void tempFolderIsNotSymbolicLink() {
-		assertThat(testFolder, is(not(symbolicLink())));
+		assertThat(testFolder, is(not(aSymbolicLink())));
 	}
 
 	@Test
 	public void testFileIsNotSymbolicLink() {
-		assertThat(testFile, is(not(symbolicLink())));
+		assertThat(testFile, is(not(aSymbolicLink())));
 	}
 
 	@Test
 	public void linkFileIsSymbolicLink() {
 		assumeThat(linkFile, notNullValue());
-		assertThat(linkFile, is(symbolicLink()));
+		assertThat(linkFile, is(aSymbolicLink()));
 	}
 
 	@Test
 	public void noFileIsNotSymbolicLink() {
-		assertThat(noFile, is(not(symbolicLink())));
+		assertThat(noFile, is(not(aSymbolicLink())));
 	}
 
 	@Test
 	public void isNotSymbolicLinkDescription() {
-		String description = mismatchDescriptionFor(noFile, symbolicLink());
+		String description = mismatchDescriptionFor(noFile, aSymbolicLink());
 		assertThat(description, both(containsString("a symbolic link")).and(containsString(" does not exist")));
 	}
 


### PR DESCRIPTION
symbolicLink() changed to aSymbolicLink(), to be more like other methods names, & "read" better.  e.g.)
`assertThat(path, is(aSymbolicLink()))`

Removed @Factory markers, as automatic generation of Hamcrest Matchers is not used.
